### PR TITLE
[feature] Generic Exceptions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -274,6 +274,7 @@ export class Try {
    *
    * if (result.isOK()) return result.hostname
    * ```
+   * @note this is a beta feature and subject to change.
    *
    */
   static init<T, A extends any[] = any[], Err extends Error = Error>(

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ export type ErrorTuple<E = Error> = [undefined, E]
 /**
  * Result tuple which contains a value.
  */
-export type TryResultOk<T, E> = Res<T, E> & {
+export type TryResultOk<T, E = Error> = Res<T, never> & {
   0: T
   1: undefined
   value: T
@@ -23,7 +23,7 @@ export type TryResultOk<T, E> = Res<T, E> & {
 /**
  * Result tuple which contains an error.
  */
-export type TryResultError<T, E> = Res<never, E> & {
+export type TryResultError<T, E = Error> = Res<never, E> & {
   0: undefined
   1: Error
   value: undefined
@@ -46,7 +46,7 @@ export type TryResult<T, E = Error> =
  * several convenience methods for accessing data and checking types.
  *
  */
-export class Res<T, E> extends Array {
+export class Res<T, E = Error> extends Array {
   /**
    * Helper to convert a caught exception to an Error instance.
    */
@@ -57,19 +57,19 @@ export class Res<T, E> extends Array {
   /**
    * Helper methods for instantiating via a tuple.
    */
-  static from<G, Err = Error>(tuple: ErrorTuple): TryResultError<never, Err>
-  static from<G, Err = Error>(tuple: OkTuple<G>): TryResultOk<G, never>
-  static from<G, Err = Error>(
-    tuple: OkTuple<G> | ErrorTuple
-  ): TryResult<G, Err> {
-    return new Res(tuple) as TryResult<G, Err>
+  static from<Val, Err = Error>(tuple: ErrorTuple): TryResultError<never, Err>
+  static from<Val, Err = Error>(tuple: OkTuple<Val>): TryResultOk<Val, never>
+  static from<Val, Err = Error>(
+    tuple: OkTuple<Val> | ErrorTuple
+  ): TryResult<Val, Err> {
+    return new Res(tuple) as TryResult<Val, Err>
   }
 
-  static ok<G>(value: G): TryResultOk<G, never> {
+  static ok<Val>(value: Val): TryResultOk<Val, never> {
     return Res.from([value, undefined])
   }
 
-  static err<Err>(exception: unknown): TryResultError<never, Err> {
+  static err<Err = Error>(exception: unknown): TryResultError<never, Err> {
     return Res.from([undefined, Res.toError(exception)])
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -180,6 +180,13 @@ export class Res<T, E extends Error = Error> extends Array {
 }
 
 /**
+ * Special Types
+ */
+type GenericConstructor<T, Args extends any[] = any[]> = {
+  new (...args: Args): T
+}
+
+/**
  * ## Try
  *
  * This class provides several utility methods for error handling and catching
@@ -254,6 +261,18 @@ export class Try {
     } catch (e) {
       return Res.err(e)
     }
+  }
+
+  /**
+   * Utility for initializing a class instance
+   */
+  static init<T, A extends any[] = any[], Err extends Error = Error>(
+    ctor: GenericConstructor<T, A>,
+    ...args: A
+  ) {
+    return Try.catch<InstanceType<typeof ctor>, Err>(() => {
+      return new ctor(...args)
+    })
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,12 +6,12 @@ export type OkTuple<T> = [T, undefined]
 /**
  * Primitive result tuple which contains an error.
  */
-export type ErrorTuple<E = Error> = [undefined, E]
+export type ErrorTuple<E extends Error = Error> = [undefined, E]
 
 /**
  * Result tuple which contains a value.
  */
-export type TryResultOk<T, E = Error> = Res<T, never> & {
+export type TryResultOk<T, E extends Error = Error> = Res<T, never> & {
   0: T
   1: undefined
   value: T
@@ -23,7 +23,7 @@ export type TryResultOk<T, E = Error> = Res<T, never> & {
 /**
  * Result tuple which contains an error.
  */
-export type TryResultError<T, E = Error> = Res<never, E> & {
+export type TryResultError<T, E extends Error = Error> = Res<never, E> & {
   0: undefined
   1: Error
   value: undefined
@@ -35,7 +35,7 @@ export type TryResultError<T, E = Error> = Res<never, E> & {
 /**
  * Result tuple returned from calling `Try.catch(fn)`
  */
-export type TryResult<T, E = Error> =
+export type TryResult<T, E extends Error = Error> =
   | TryResultOk<T, never>
   | TryResultError<never, E>
 
@@ -46,7 +46,7 @@ export type TryResult<T, E = Error> =
  * several convenience methods for accessing data and checking types.
  *
  */
-export class Res<T, E = Error> extends Array {
+export class Res<T, E extends Error = Error> extends Array {
   /**
    * Helper to convert a caught exception to an Error instance.
    */
@@ -57,19 +57,31 @@ export class Res<T, E = Error> extends Array {
   /**
    * Helper methods for instantiating via a tuple.
    */
-  static from<Val, Err = Error>(tuple: ErrorTuple): TryResultError<never, Err>
-  static from<Val, Err = Error>(tuple: OkTuple<Val>): TryResultOk<Val, never>
-  static from<Val, Err = Error>(
+  static from<Val, Err extends Error = Error>(
+    tuple: ErrorTuple
+  ): TryResultError<never, Err>
+  static from<Val, Err extends Error = Error>(
+    tuple: OkTuple<Val>
+  ): TryResultOk<Val, never>
+  static from<Val, Err extends Error = Error>(
     tuple: OkTuple<Val> | ErrorTuple
   ): TryResult<Val, Err> {
     return new Res(tuple) as TryResult<Val, Err>
   }
 
+  /**
+   * Instantiate a new result tuple with a value.
+   */
   static ok<Val>(value: Val): TryResultOk<Val, never> {
     return Res.from([value, undefined])
   }
 
-  static err<Err = Error>(exception: unknown): TryResultError<never, Err> {
+  /**
+   * Instantiate a new result tuple with an error.
+   */
+  static err<Err extends Error = Error>(
+    exception: unknown
+  ): TryResultError<never, Err> {
     return Res.from([undefined, Res.toError(exception)])
   }
 
@@ -220,11 +232,15 @@ export class Try {
    *  return jsonData
    * ```
    */
-  static catch<T, Err = Error>(fn: () => never): TryResultError<never, Err>
-  static catch<T, Err = Error>(fn: () => Promise<T>): Promise<TryResult<T, Err>>
-  static catch<T, Err = Error>(fn: () => T): TryResult<T, Err>
-  static catch<T, Err = Error>(
-    fn: () => T | Promise<T>
+  static catch<T, Err extends Error = Error>(
+    fn: () => never
+  ): TryResultError<never, Err>
+  static catch<T, Err extends Error = Error>(
+    fn: () => Promise<T>
+  ): Promise<TryResult<T, Err>>
+  static catch<T, Err extends Error = Error>(fn: () => T): TryResult<T, Err>
+  static catch<T, Err extends Error = Error>(
+    fn: () => T | never | Promise<T>
   ): TryResult<T, Err> | Promise<TryResult<T, Err>> {
     try {
       const output = fn()

--- a/src/index.ts
+++ b/src/index.ts
@@ -264,13 +264,23 @@ export class Try {
   }
 
   /**
-   * Utility for initializing a class instance
+   * Utility for initializing a class instance with the given parameters
+   * and catching any exceptions thrown. Will return a result tuple of
+   * either the class instance or error thrown.
+   *
+   * ```ts
+   * // example instantiating a new URL instance
+   * const result = Try.init(URL, "https://www.typescriptlang.org/")
+   *
+   * if (result.isOK()) return result.hostname
+   * ```
+   *
    */
   static init<T, A extends any[] = any[], Err extends Error = Error>(
-    ctor: GenericConstructor<T, A>,
+    ctor: new (...args: A) => T,
     ...args: A
   ) {
-    return Try.catch<InstanceType<typeof ctor>, Err>(() => {
+    return Try.catch<T, Err>(() => {
       return new ctor(...args)
     })
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,8 +50,16 @@ export class Res<T, E extends Error = Error> extends Array {
   /**
    * Helper to convert a caught exception to an Error instance.
    */
-  static toError = (exception: unknown): Error => {
-    return exception instanceof Error ? exception : new Error(String(exception))
+  static toError = <Err extends Error = Error>(exception: unknown) => {
+    return exception instanceof Error
+      ? exception
+      : (new Error(String(exception)) as Err)
+  }
+
+  static isError = <Err extends Error = Error>(
+    exception: unknown
+  ): exception is Err => {
+    return exception instanceof Error
   }
 
   /**
@@ -180,13 +188,6 @@ export class Res<T, E extends Error = Error> extends Array {
 }
 
 /**
- * Special Types
- */
-type GenericConstructor<T, Args extends any[] = any[]> = {
-  new (...args: Args): T
-}
-
-/**
  * ## Try
  *
  * This class provides several utility methods for error handling and catching
@@ -220,6 +221,14 @@ type GenericConstructor<T, Args extends any[] = any[]> = {
  *
  */
 export class Try {
+  /**
+   * Allows overriding some of the default properties such as how to handle exceptions
+   * and how tht result class should look.
+   */
+  static onException<E extends Error>(handler: (exception: unknown) => E) {
+    Res.toError = handler
+  }
+
   /**
    * Simple error handling utility which will invoke the provided function and
    * catch any thrown errors, the result of the function execution will then be

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -21,6 +21,7 @@ test('Can use vet shorthand utility with or chaining', () => {
   expect(link instanceof URL).toBe(true)
 })
 
+// Result can call result helper methods isOk and isErr
 test('Res can call the isOk() and isErr() methods', async () => {
   let resultError = Try.catch(() => {
     throw new Error('alwaysThrows')
@@ -510,6 +511,38 @@ test('Can specify specific type of Error to expect', () => {
   }
 
   const result = Try.catch<string, CustomError>(canThrow)
+  expect(result.ok).toBe(false)
+  expect(result.isOk()).toBe(false)
+  expect(result.isErr()).toBe(true)
+  expect(result.error instanceof CustomError).toBe(true)
+  expect(result.error!.code).toBe(117)
+  expect(result.toString()).toBe('Result.Error(MyCustomError)')
+})
+
+/**
+ * Check if `Try.expect()` works as expected and contains proper types.
+ */
+test('Can call Try.expect with custom error type as first generic argument', () => {
+  class CustomError extends Error {
+    public name = 'MyCustomError'
+    public code = 117
+    get [Symbol.toStringTag]() {
+      console.log('toStringTag called!')
+      return 'CustomError'
+    }
+  }
+
+  class CustomObject {}
+
+  function canThrow(): CustomObject | never {
+    if (Math.random() < 1.0) {
+      throw new CustomError()
+    } else {
+      return new CustomObject()
+    }
+  }
+
+  const result = Try.catch<CustomObject, CustomError>(canThrow)
   expect(result.ok).toBe(false)
   expect(result.isOk()).toBe(false)
   expect(result.isErr()).toBe(true)

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -454,7 +454,7 @@ test('Can call toString on Res class', () => {
   const result2 = Try.catch(() => {
     throw new Error('456')
   })
-  expect(result2.toString()).toBe('Result.Error(456)')
+  expect(result2.toString()).toBe('Result.Error(Error: 456)')
 })
 
 test('Can create result tuple with Res.ok', () => {
@@ -469,4 +469,21 @@ test('Can create result tuple with Res.ok', () => {
   expect(edgeCase1.isOk()).toBe(true)
   expect(edgeCase1.isErr()).toBe(false)
   expect(edgeCase1.unwrap()).toBeUndefined()
+})
+
+
+test('Can handle multiple statements', () => {
+
+  const userInput = ""
+  const INVALID_CHARS = /[A-Z]/g
+  const FALLBACK_URL = new URL("https://example.com")
+
+  const url = Try.catch(() => new URL(userInput))
+  .or(() => new URL(`https://${userInput}`))
+  .or(() => new URL(`https://${userInput.replace('http://', '')}`))
+  .or(() => new URL(`https://${userInput.split('://')[1]!.trim()}`))
+  .unwrapOr(new URL(FALLBACK_URL))
+
+  expect(url.href).toBe("https://example.com/")
+
 })

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -569,7 +569,30 @@ test('Can call Try.init() to instantiate an instance of a class', () => {
 test('Can call Try.init() to instantiate an instance of a class', () => {
   // @ts-ignore
   const result = Try.init(URL, 'https://asleepace.com/', 123, 435)
-  console.log(result.value)
   expect(result.isErr()).toBe(true)
   expect(result.value instanceof URL).toBe(false)
+})
+
+/**
+ * Can set custom configuration for handling exceptions.
+ */
+test('Can set custom configuration for handling errors', () => {
+  class MyCustomError extends Error {
+    static isCustom = true
+    constructor(message: unknown) {
+      super(String(message))
+    }
+  }
+
+  Try.onException((exception) => {
+    return new MyCustomError(exception)
+  })
+
+  const result = Try.catch(() => {
+    throw new Error('always')
+  })
+
+  expect(result.isOk()).toBe(false)
+  expect(result.isErr()).toBe(true)
+  expect(result.error instanceof MyCustomError).toBe(true)
 })

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -556,9 +556,20 @@ test('Can call Try.expect with custom error type as first generic argument', () 
  */
 test('Can call Try.init() to instantiate an instance of a class', () => {
   const result = Try.init(URL, 'https://asleepace.com/')
-  expect(result.isOk())
+  expect(result.isOk()).toBe(true)
   if (result.isOk()) {
     expect(result.value.href).toEqual('https://asleepace.com/')
   }
-  expect(result.value instanceof URL)
+  expect(result.value instanceof URL).toBe(true)
+})
+
+/**
+ * Check if `Try.init(URL)` works with invalid parameters.
+ */
+test('Can call Try.init() to instantiate an instance of a class', () => {
+  // @ts-ignore
+  const result = Try.init(URL, 'https://asleepace.com/', 123, 435)
+  console.log(result.value)
+  expect(result.isErr()).toBe(true)
+  expect(result.value instanceof URL).toBe(false)
 })

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -550,3 +550,15 @@ test('Can call Try.expect with custom error type as first generic argument', () 
   expect(result.error!.code).toBe(117)
   expect(result.toString()).toBe('Result.Error(MyCustomError)')
 })
+
+/**
+ * Check if `Try.init(URL, urlString)` works as expected.
+ */
+test('Can call Try.init() to instantiate an instance of a class', () => {
+  const result = Try.init(URL, 'https://asleepace.com/')
+  expect(result.isOk())
+  if (result.isOk()) {
+    expect(result.value.href).toEqual('https://asleepace.com/')
+  }
+  expect(result.value instanceof URL)
+})


### PR DESCRIPTION
# Description

This pull request adds support for generic exceptions which default to the `Error` type, but can also be specified by the caller.

## Why?

Exceptions in JS and TS don't have to conform to the built-in Error class, and really you can throw anything. Previously this package coerced the exceptions into the Error class, but this pull request adds support for changing this default behavior.